### PR TITLE
Add sector manager utility module

### DIFF
--- a/sector_manager.py
+++ b/sector_manager.py
@@ -1,0 +1,51 @@
+import json
+import os
+from typing import Optional, Dict
+
+FILE_PATH = os.path.join(os.path.dirname(__file__), "custom_sectors.json")
+
+
+def load_custom_sectors() -> Dict[str, str]:
+    """Load user defined sector mappings from JSON file.
+
+    Returns an empty dict if the file does not exist, is invalid or any
+    error occurs. Creates the file if it's missing.
+    """
+    if os.path.exists(FILE_PATH):
+        try:
+            with open(FILE_PATH, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                if isinstance(data, dict):
+                    return data
+        except Exception:
+            return {}
+        return {}
+    else:
+        try:
+            with open(FILE_PATH, "w", encoding="utf-8") as f:
+                json.dump({}, f, indent=2, ensure_ascii=False)
+        except Exception:
+            pass
+        return {}
+
+
+def save_custom_sectors(data: Dict[str, str]) -> None:
+    """Persist the given sector mappings dictionary to disk."""
+    try:
+        with open(FILE_PATH, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+    except Exception:
+        pass
+
+
+def get_sector_from_cache(symbol: str) -> Optional[str]:
+    """Return cached sector for the provided symbol if available."""
+    data = load_custom_sectors()
+    return data.get(symbol)
+
+
+def add_sector(symbol: str, sector: str) -> None:
+    """Add or update a symbol to sector mapping and persist it."""
+    data = load_custom_sectors()
+    data[symbol] = sector
+    save_custom_sectors(data)


### PR DESCRIPTION
## Summary
- implement `sector_manager.py` to manage a persistent `custom_sectors.json` file
- provide helper functions to load, save, query and add custom sector mappings

## Testing
- `python -m py_compile sector_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_684e8f84ac5c8322b2b9aba629064e48