### PR TITLE
Add yfinance sector utility

### DIFF
--- a/data_fetcher/yfinance_data.py
+++ b/data_fetcher/yfinance_data.py
@@ -1,0 +1,18 @@
+import yfinance as yf
+
+
+def get_sector_yf(symbol: str) -> str:
+    """Return the sector for the given stock symbol using yfinance.
+
+    If the sector cannot be determined or an error occurs, return
+    an empty string.
+    """
+    try:
+        ticker = yf.Ticker(symbol)
+        info = ticker.info
+        sector = info.get("sector")
+        if isinstance(sector, str):
+            return sector
+    except Exception:
+        pass
+    return ""


### PR DESCRIPTION
## Summary
- add a data_fetcher module for retrieving sector via yfinance

## Testing
- `python3 - <<'EOF'
from data_fetcher.yfinance_data import get_sector_yf
print('AAPL sector:', get_sector_yf('AAPL'))
print('Invalid sector:', get_sector_yf('INVALIDSYM'))
print('Module imported successfully')
EOF`


------
https://chatgpt.com/codex/tasks/task_e_684ea346939c8322a66ca0003c0284c9