### PR TITLE
Improve table layout

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5,16 +5,23 @@
     <title>SKY INDEX</title>
     <style>
         body { font-family: Arial, sans-serif; background-color: #f0f2f5; padding: 20px; }
-        table { border-collapse: collapse; width: 100%; margin-top: 20px; }
+        table { border-collapse: collapse; margin-top: 20px; table-layout: fixed; }
         th, td { border: 1px solid #ddd; padding: 2px; text-align: left; }
         th { background-color: #4CAF50; color: white; }
-        input, select { width: 100%; min-width: 110px; padding: 4px; font-size: 14px; box-sizing: border-box; }
-        .symbol-input { width: 99px; }
-        .sector-select { width: 121px; }
+        input, select { width: 100%; padding: 4px; font-size: 14px; box-sizing: border-box; }
+        select.sector-select { font-size: 13px; }
+        .table-wrapper { overflow-x: auto; max-width: 100%; }
+        .symbol-input { width: 80px; }
+        .sector-select { width: 170px; }
         .zacks-output { width: 35px; }
-        th[title] { position: relative; }
-        th[title]:hover::after {
-            content: attr(title);
+        .sector-growth { width: 110px; }
+        .eps-growth { width: 110px; }
+        .revenue-growth { width: 110px; }
+        .pe-ratio { width: 80px; }
+        .volume-change { width: 110px; }
+        th[data-tooltip] { position: relative; }
+        th[data-tooltip]:hover::after {
+            content: attr(data-tooltip);
             position: absolute;
             bottom: 100%;
             left: 0;
@@ -24,6 +31,7 @@
             white-space: nowrap;
             border-radius: 3px;
             font-size: 12px;
+            z-index: 2;
         }
         button { padding: 6px; font-size: 14px; margin: 2px; }
     </style>
@@ -34,19 +42,20 @@
         <label>Кількість рядків: </label>
         <input type="number" name="rows_count" min="1" max="50" value="{{ rows|length }}">
         <button name="action" value="resize">Оновити</button>
+        <div class="table-wrapper">
         <table>
             <thead>
                 <tr>
-                    <th title="Біржовий тикер акції або ETF">Symbol</th>
-                    <th title="Галузь, до якої належить компанія">Sector</th>
-                    <th title="Рейтинг Zacks від 1 (сильна покупка) до 5 (продаж)">Zacks</th>
-                    <th title="Зміна ціни галузевого ETF за певний період">Sector Growth</th>
-                    <th title="Ріст прибутку на акцію за рік або квартал">EPS Growth</th>
-                    <th title="Зростання виручки компанії">Revenue Growth</th>
-                    <th title="Співвідношення ціни до прибутку">PE Ratio</th>
-                    <th title="Зміна обсягу торгів за добу">Volume Change</th>
-                    <th title="Підсумкова оцінка моделі">Оцінка</th>
-                    <th title="Дата, на яку зібрані ці дані">Дата</th>
+                    <th data-tooltip="Біржовий тикер акції або ETF">Symbol</th>
+                    <th data-tooltip="Галузь, до якої належить компанія">Sector</th>
+                    <th data-tooltip="Рейтинг Zacks від 1 (сильна покупка) до 5 (продаж)">Zacks</th>
+                    <th data-tooltip="Зміна ціни галузевого ETF за певний період">Sector Growth</th>
+                    <th data-tooltip="Ріст прибутку на акцію за рік або квартал">EPS Growth</th>
+                    <th data-tooltip="Зростання виручки компанії">Revenue Growth</th>
+                    <th data-tooltip="Співвідношення ціни до прибутку">PE Ratio</th>
+                    <th data-tooltip="Зміна обсягу торгів за добу">Volume Change</th>
+                    <th data-tooltip="Підсумкова оцінка моделі">Оцінка</th>
+                    <th data-tooltip="Дата, на яку зібрані ці дані">Дата</th>
                 </tr>
             </thead>
             <tbody>
@@ -63,17 +72,18 @@
                         </select>
                     </td>
                     <td><input type="text" class="zacks-output" name="zacks_{{ i }}" value="{{ row['Zacks'] }}"></td>
-                    <td><input type="text" name="sector_growth_{{ i }}" value="{{ row['Sector Growth'] }}"></td>
-                    <td><input type="text" name="eps_growth_{{ i }}" value="{{ row['EPS Growth'] }}"></td>
-                    <td><input type="text" name="revenue_growth_{{ i }}" value="{{ row['Revenue Growth'] }}"></td>
-                    <td><input type="text" name="pe_ratio_{{ i }}" value="{{ row['PE Ratio'] }}"></td>
-                    <td><input type="text" name="volume_change_{{ i }}" value="{{ row['Volume Change'] }}"></td>
-                    <td>{{ row['Оцінка'] }}</td>
-                    <td>{{ row['Дата'] }}</td>
+                    <td><input type="text" class="sector-growth" name="sector_growth_{{ i }}" value="{{ row['Sector Growth'] }}"></td>
+                    <td><input type="text" class="eps-growth" name="eps_growth_{{ i }}" value="{{ row['EPS Growth'] }}"></td>
+                    <td><input type="text" class="revenue-growth" name="revenue_growth_{{ i }}" value="{{ row['Revenue Growth'] }}"></td>
+                    <td><input type="text" class="pe-ratio" name="pe_ratio_{{ i }}" value="{{ row['PE Ratio'] }}"></td>
+                    <td><input type="text" class="volume-change" name="volume_change_{{ i }}" value="{{ row['Volume Change'] }}"></td>
+                    <td style="width: 60px;">{{ row['Оцінка'] }}</td>
+                    <td style="width: 90px;">{{ row['Дата'] }}</td>
                 </tr>
                 {% endfor %}
             </tbody>
         </table>
+        </div>
         <br>
         <button name="action" value="parse">Парсинг</button>
         <button name="action" value="evaluate">Оцінка</button>


### PR DESCRIPTION
## Summary
- make table wrapper horizontally scrollable
- set fixed column widths and table layout
- use CSS tooltips instead of native titles
- reduce font size in sector dropdown

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_684ebf7ddaa883229ef5e4961f9537d0