### PR TITLE
Add async save feature

### DIFF
--- a/static/save.js
+++ b/static/save.js
@@ -1,0 +1,55 @@
+async function handleSave() {
+    const rows = Array.from(document.querySelectorAll('tbody tr'))
+        .filter(tr => tr.dataset.status !== 'ok')
+        .map(tr => {
+            const getVal = selector => tr.querySelector(selector)?.value.trim() || '';
+            return {
+                symbol: getVal('.symbol-input').toUpperCase(),
+                Sector: getVal('.sector-select'),
+                Zacks: getVal('.zacks-output'),
+                'Sector Growth': getVal('.sector-growth'),
+                'EPS Growth': getVal('.eps-growth'),
+                'Revenue Growth': getVal('.revenue-growth'),
+                'PE Ratio': getVal('.pe-ratio'),
+                'Volume Change': getVal('.volume-change'),
+                'Дата': tr.querySelector('.date-cell')?.textContent.trim() || ''
+            };
+        });
+
+    if (rows.length === 0) {
+        alert('No rows to save');
+        return;
+    }
+
+    try {
+        const response = await fetch('/save', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(rows)
+        });
+        const results = await response.json();
+        results.forEach(res => {
+            const symbol = (res.symbol || '').toUpperCase();
+            const tr = Array.from(document.querySelectorAll('tbody tr'))
+                .find(r => r.querySelector('.symbol-input')?.value.trim().toUpperCase() === symbol);
+            if (!tr) return;
+            if (res.status === 'ok') {
+                tr.dataset.status = 'ok';
+                tr.classList.remove('row-error');
+                tr.classList.add('row-ok');
+                tr.title = '';
+            } else if (res.status === 'error') {
+                tr.dataset.status = 'error';
+                tr.classList.remove('row-ok');
+                tr.classList.add('row-error');
+                if (res.reason) {
+                    tr.title = res.reason;
+                    alert(symbol + ': ' + res.reason);
+                }
+            }
+        });
+    } catch (err) {
+        console.log('Save failed', err);
+        alert('Failed to save data');
+    }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -79,6 +79,8 @@
             font-size: 14px;
             margin: 2px;
         }
+        .row-ok { background-color: #d4edda; }
+        .row-error { background-color: #f8d7da; }
         .row-control {
             display: flex;
             align-items: center;
@@ -117,7 +119,7 @@
                 <tbody>
                     {% for row in rows %}
                     {% set i = loop.index0 %}
-                    <tr>
+                    <tr data-row-id="{{ i }}" data-status="">
                         <td><input type="text" class="symbol-input" name="symbol_{{ i }}" value="{{ row['Symbol'] }}"></td>
                         <td>
                             <select name="sector_{{ i }}" class="sector-select">
@@ -134,7 +136,7 @@
                         <td><input type="text" class="pe-ratio" name="pe_ratio_{{ i }}" value="{{ row['PE Ratio'] }}"></td>
                         <td><input type="text" class="volume-change" name="volume_change_{{ i }}" value="{{ row['Volume Change'] }}"></td>
                         <td style="width: 60px;">{{ row['Оцінка'] }}</td>
-                        <td style="width: 90px;">{{ row['Дата'] }}</td>
+                        <td class="date-cell" style="width: 90px;">{{ row['Дата'] }}</td>
                     </tr>
                     {% endfor %}
                 </tbody>
@@ -144,7 +146,8 @@
         <br>
         <button name="action" value="parse">Парсинг</button>
         <button name="action" value="evaluate">Оцінка</button>
-        <button name="action" value="save">Зберегти</button>
+        <button type="button" onclick="handleSave()">Зберегти</button>
     </form>
+    <script src="{{ url_for('static', filename='save.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add data attributes and row status UI colors to `index.html`
- implement an async `handleSave()` function
- include minimal CSS for row-ok/error feedback
- reference new script in the template

## Testing
- `python -m py_compile app.py logic/normalization.py logic/save_handler.py`
- `node -e "require('fs').readFileSync('static/save.js','utf8'); console.log('ok')"`


------
https://chatgpt.com/codex/tasks/task_e_684f49c055c08322969e5f143286eec3