### PR TITLE
Skip invalid metric rows

### DIFF
--- a/logic/normalization.py
+++ b/logic/normalization.py
@@ -90,6 +90,10 @@ def normalize_row(row: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         'volume_change_norm': volume_change_norm,
     }
 
+    # If all normalized values are None → treat row as invalid
+    if all(v is None for v in metrics.values()):
+        return None
+
     return {
         'symbol': symbol,
         'date': date_str,


### PR DESCRIPTION
## Summary
- normalize_row now rejects rows when all metrics are `None`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f5497c4508322be47e3b113b0695f