### PR TITLE
Add skyindex_score column and UI display

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
 from flask import Flask, render_template, request, jsonify
 from datetime import datetime
 from data_fetcher.zacks import get_zacks_rank
-from logic.rating import evaluate_rating
 from sector_manager import get_sector_from_cache, add_sector
 from data_fetcher.yfinance_data import get_sector_yf
 from logic.normalization import normalize_row
@@ -46,7 +45,7 @@ def empty_row():
     return {
         "Symbol": "",
         **{key: "" for key in HEADERS},
-        "Оцінка": "-",
+        "skyindex_score": None,
         "Дата": ""
     }
 
@@ -132,9 +131,6 @@ def index():
                 parsed = parse_data(symbol)
                 for key, value in parsed.items():
                     rows[i][key] = value
-                rows[i]['Дата'] = datetime.today().strftime('%Y-%m-%d')
-            elif action == "evaluate":
-                rows[i]['Оцінка'] = evaluate_rating(rows[i])
                 rows[i]['Дата'] = datetime.today().strftime('%Y-%m-%d')
             elif action == "save":
                 if symbol and rows[i].get('Sector'):

--- a/database/database.py
+++ b/database/database.py
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS stock_metrics (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     symbol TEXT,
     zacks_rank_norm REAL,
+    skyindex_score REAL,
     date TEXT
 );
 """

--- a/logic/normalization.py
+++ b/logic/normalization.py
@@ -1,6 +1,8 @@
 import datetime
 from typing import Any, Dict, Optional
 
+from .rating import calculate_skyindex_score
+
 
 def _get_value(data: Dict[str, Any], *keys: str) -> Optional[str]:
     """Return first matching key from data in case-insensitive manner."""
@@ -94,6 +96,8 @@ def normalize_row(row: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     if all(v is None for v in metrics.values()):
         return None
 
+    skyindex_score = calculate_skyindex_score(metrics)
+
     return {
         'symbol': symbol,
         'date': date_str,
@@ -102,4 +106,5 @@ def normalize_row(row: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         'close_price': None,
         'price_change_today': None,
         'price_at_parse': None,
+        'skyindex_score': skyindex_score,
     }

--- a/logic/rating.py
+++ b/logic/rating.py
@@ -1,3 +1,6 @@
+from typing import Any, Dict, Optional
+
+
 def evaluate_rating(data):
     score = 0
 
@@ -20,3 +23,12 @@ def evaluate_rating(data):
         score += 1
 
     return f"{score}/3"
+
+
+def calculate_skyindex_score(metrics: Dict[str, Any]) -> Optional[float]:
+    """Returns the normalized Zacks Rank as the skyindex_score."""
+    value = metrics.get("zacks_rank_norm")
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/logic/save_handler.py
+++ b/logic/save_handler.py
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS stock_metrics (
   close_price REAL,
   price_change_today REAL,
   price_at_parse REAL,
+  skyindex_score REAL,
   metrics TEXT,
   UNIQUE(symbol, date)
 );
@@ -38,13 +39,14 @@ def save_row(row: Dict[str, Any]) -> Dict[str, Any]:
 
             sql = (
                 "INSERT INTO stock_metrics (symbol, date, open_price, close_price, "
-                "price_change_today, price_at_parse, metrics) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?) "
+                "price_change_today, price_at_parse, skyindex_score, metrics) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
                 "ON CONFLICT(symbol, date) DO UPDATE SET "
                 "open_price=excluded.open_price, "
                 "close_price=excluded.close_price, "
                 "price_change_today=excluded.price_change_today, "
                 "price_at_parse=excluded.price_at_parse, "
+                "skyindex_score=excluded.skyindex_score, "
                 "metrics=excluded.metrics"
             )
 
@@ -57,6 +59,7 @@ def save_row(row: Dict[str, Any]) -> Dict[str, Any]:
                     row.get("close_price"),
                     row.get("price_change_today"),
                     row.get("price_at_parse"),
+                    row.get("skyindex_score"),
                     json.dumps(metrics),
                 ),
             )

--- a/templates/index.html
+++ b/templates/index.html
@@ -112,7 +112,7 @@
                         <th data-tooltip="Зростання виручки компанії">Revenue Growth</th>
                         <th data-tooltip="Співвідношення ціни до прибутку">PE Ratio</th>
                         <th data-tooltip="Зміна обсягу торгів за добу">Volume Change</th>
-                        <th data-tooltip="Підсумкова оцінка моделі">Оцінка</th>
+                        <th data-tooltip="Підсумкова оцінка моделі">SkyIndex</th>
                         <th data-tooltip="Дата, на яку зібрані ці дані">Дата</th>
                     </tr>
                 </thead>
@@ -135,7 +135,11 @@
                         <td><input type="text" class="revenue-growth" name="revenue_growth_{{ i }}" value="{{ row['Revenue Growth'] }}"></td>
                         <td><input type="text" class="pe-ratio" name="pe_ratio_{{ i }}" value="{{ row['PE Ratio'] }}"></td>
                         <td><input type="text" class="volume-change" name="volume_change_{{ i }}" value="{{ row['Volume Change'] }}"></td>
-                        <td style="width: 60px;">{{ row['Оцінка'] }}</td>
+                        <td style="width: 60px;">
+                            {% if row['skyindex_score'] is not none %}
+                                {{ '%.2f'|format(row['skyindex_score']) }}
+                            {% endif %}
+                        </td>
                         <td class="date-cell" style="width: 90px;">{{ row['Дата'] }}</td>
                     </tr>
                     {% endfor %}
@@ -145,7 +149,6 @@
 
         <br>
         <button name="action" value="parse">Парсинг</button>
-        <button name="action" value="evaluate">Оцінка</button>
         <button type="button" onclick="handleSave()">Зберегти</button>
     </form>
     <script src="{{ url_for('static', filename='save.js') }}"></script>


### PR DESCRIPTION
## Summary
- compute `skyindex_score` from Zacks rank
- include `skyindex_score` in normalized rows
- store the score in `stock_metrics` table
- show the score in the index page
- drop legacy rating field

## Testing
- `python -m py_compile app.py logic/*.py database/database.py`


------
https://chatgpt.com/codex/tasks/task_e_684ff77d6e38832299c6cb1243d5eeff