### PR TITLE
Fix dropdown error state removal

### DIFF
--- a/static/save.js
+++ b/static/save.js
@@ -59,3 +59,12 @@ async function handleSave() {
         alert('Failed to save data');
     }
 }
+
+// Remove error highlighting from sector dropdowns once a valid value is chosen
+document.querySelectorAll('.sector-select').forEach(sel => {
+    sel.addEventListener('change', () => {
+        if (sel.value.trim() !== '') {
+            sel.removeAttribute('data-status');
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- clear `data-status` attribute when user selects a non-empty sector

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68501e98953c8322a5aeda3b16c7c7c1