### PR TITLE
Standardize sector dropdown list

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,19 +22,16 @@ HEADERS = [
 # Варіанти секторів для випадаючого списку
 SECTOR_OPTIONS = [
     "Technology",
-    "Financial Services",
+    "Financials",
     "Healthcare",
     "Communication Services",
-    "Consumer Cyclical",
-    "Consumer Defensive",
+    "Consumer Discretionary",
+    "Consumer Staples",
     "Industrials",
-    "Basic Materials",
+    "Materials",
+    "Energy",
     "Utilities",
     "Real Estate",
-    "Energy",
-    "Broad Market",
-    "Bonds",
-    "Innovation",
 ]
 
 def field_name(key: str) -> str:

--- a/templates/index.html
+++ b/templates/index.html
@@ -126,7 +126,7 @@
                         <td><input type="text" class="symbol-input" name="symbol_{{ i }}" value="{{ row['Symbol'] }}" autocomplete="off"></td>
                         <td>
                             <select name="sector_{{ i }}" class="sector-select">
-                                <option value=""></option>
+                                <option value="">-</option>
                                 {% for opt in sectors %}
                                     <option value="{{ opt }}" {% if row['Sector'] == opt %}selected{% endif %}>{{ opt }}</option>
                                 {% endfor %}


### PR DESCRIPTION
## Summary
- update list of sectors in backend to final GICS set
- show dash for empty sector option in UI

## Testing
- `python -m py_compile $(find . -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685041dc5ed08322aa033a2f3846b437