### PR TITLE
Normalize yfinance sector names

### DIFF
--- a/data_fetcher/yfinance_data.py
+++ b/data_fetcher/yfinance_data.py
@@ -1,18 +1,38 @@
 import yfinance as yf
 
+# Mapping of raw yfinance sector names to the normalized sector values
+# used in the dropdown UI.
+SECTOR_MAP = {
+    "Financial Services": "Financials",
+    "Consumer Cyclical": "Consumer Discretionary",
+    "Consumer Defensive": "Consumer Staples",
+    "Basic Materials": "Materials",
+    "Technology": "Technology",
+    "Healthcare": "Healthcare",
+    "Energy": "Energy",
+    "Utilities": "Utilities",
+    "Real Estate": "Real Estate",
+    "Communication Services": "Communication Services",
+    "Industrials": "Industrials",
+}
 
-def get_sector_yf(symbol: str) -> str:
-    """Return the sector for the given stock symbol using yfinance.
 
-    If the sector cannot be determined or an error occurs, return
-    an empty string.
+def get_sector_yf(symbol: str):
+    """Return the normalized sector for the given stock symbol via yfinance.
+
+    If the sector cannot be determined or does not match one of the
+    predefined values, ``None`` is returned so the user can select it
+    manually.
     """
     try:
         ticker = yf.Ticker(symbol)
         info = ticker.info
         sector = info.get("sector")
         if isinstance(sector, str):
-            return sector
+            normalized = SECTOR_MAP.get(sector)
+            if normalized:
+                return normalized
+            return None
     except Exception:
         pass
-    return ""
+    return None


### PR DESCRIPTION
## Summary
- normalize yfinance sector names using a mapping

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install yfinance requests`

------
https://chatgpt.com/codex/tasks/task_e_68504beeabfc832296c969c8521a8d39