### PR TITLE
Implement sector growth caching and UI indicator

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,10 @@ from sector_manager import get_sector_from_cache, add_sector
 from data_fetcher.yfinance_data import get_sector_yf
 from logic.normalization import normalize_row
 from logic.save_handler import save_row
+from sector_growth_cache import load_sector_growth
+
+# Prefetch sector growth metrics on startup
+sector_growth_loaded = load_sector_growth()
 
 app = Flask(__name__)
 
@@ -149,7 +153,8 @@ def index():
                     add_sector(symbol, rows[i]['Sector'])
                     rows[i]["Дата"] = datetime.today().strftime('%Y-%m-%d')
 
-    return render_template('index.html', headers=HEADERS, rows=rows, sectors=SECTOR_OPTIONS)
+    return render_template('index.html', headers=HEADERS, rows=rows, sectors=SECTOR_OPTIONS,
+                           sector_growth_loaded=sector_growth_loaded)
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/sector_etf_map.py
+++ b/sector_etf_map.py
@@ -1,0 +1,15 @@
+# Mapping of normalized sector names to representative ETF tickers
+
+SECTOR_TO_ETF = {
+    "Technology": "XLK",
+    "Financials": "XLF",
+    "Healthcare": "XLV",
+    "Communication Services": "XLC",
+    "Consumer Discretionary": "XLY",
+    "Consumer Staples": "XLP",
+    "Industrials": "XLI",
+    "Materials": "XLB",
+    "Energy": "XLE",
+    "Utilities": "XLU",
+    "Real Estate": "XLRE",
+}

--- a/sector_growth_cache.py
+++ b/sector_growth_cache.py
@@ -1,9 +1,53 @@
-# Temporary stub for sector growth caching
+"""Cache and provide sector growth metrics based on ETF performance."""
+
+from __future__ import annotations
+
+import datetime
+
+import yfinance as yf
+
+from sector_etf_map import SECTOR_TO_ETF
+
+# In-memory cache structure populated at application startup
+SECTOR_GROWTH_CACHE: dict[str, dict[str, str]] = {}
+
+
+def load_sector_growth() -> bool:
+    """Fetch and cache recent growth metrics for all sectors.
+
+    Returns ``True`` if data for every sector could be fetched, otherwise
+    ``False``.
+    """
+    global SECTOR_GROWTH_CACHE
+    SECTOR_GROWTH_CACHE = {}
+    all_ok = True
+    today = datetime.date.today().strftime("%Y-%m-%d")
+
+    for sector, etf in SECTOR_TO_ETF.items():
+        try:
+            ticker = yf.Ticker(etf)
+            hist = ticker.history(period="8d")
+            closes = hist["Close"].dropna().tolist()
+            if len(closes) < 7:
+                all_ok = False
+                continue
+
+            g1 = (closes[-1] - closes[-2]) / closes[-2]
+            g3 = (closes[-1] - closes[-4]) / closes[-4]
+            g7 = (closes[-1] - closes[0]) / closes[0]
+
+            SECTOR_GROWTH_CACHE[sector] = {
+                "1d": f"{g1 * 100:.2f}%",
+                "3d": f"{g3 * 100:.2f}%",
+                "7d": f"{g7 * 100:.2f}%",
+                "updated": today,
+            }
+        except Exception:
+            all_ok = False
+
+    return all_ok
+
 
 def get_sector_growth(sector: str) -> str:
-    """Return growth percentage for the given sector.
-
-    This stub will later be replaced with real logic that pulls ETF-based
-    growth data. For now it just returns a placeholder value.
-    """
-    return "1.0%"
+    """Return the 1-day growth percentage for the given sector."""
+    return SECTOR_GROWTH_CACHE.get(sector, {}).get("1d", "")

--- a/templates/index.html
+++ b/templates/index.html
@@ -92,6 +92,8 @@
         .row-control input[type="number"] {
             width: 60px;
         }
+        .status.success { color: green; font-weight: bold; }
+        .status.error { color: red; font-weight: bold; }
     </style>
 </head>
 <body>
@@ -153,6 +155,11 @@
         <br>
         <button name="action" value="parse">Парсинг</button>
         <button type="button" onclick="handleSave()">Зберегти</button>
+        {% if sector_growth_loaded %}
+          <div class="status success">✅ Sector Growth loaded</div>
+        {% else %}
+          <div class="status error">⚠️ Sector Growth failed</div>
+        {% endif %}
     </form>
     <script src="{{ url_for('static', filename='save.js') }}"></script>
 </body>


### PR DESCRIPTION
## Summary
- create map of sectors to ETFs
- implement `load_sector_growth` and cache results
- pre-load sector growth metrics on startup
- show a status indicator in the UI for sector growth

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68506bf311cc8322877d10cee8bb6115