### PR TITLE
Implement calculate button for SkyIndex

### DIFF
--- a/sector_growth_cache.py
+++ b/sector_growth_cache.py
@@ -51,3 +51,8 @@ def load_sector_growth() -> bool:
 def get_sector_growth(sector: str) -> str:
     """Return the 1-day growth percentage for the given sector."""
     return SECTOR_GROWTH_CACHE.get(sector, {}).get("1d", "")
+
+
+def get_sector_growth_data(sector: str) -> dict[str, str]:
+    """Return cached growth metrics dictionary for the given sector."""
+    return SECTOR_GROWTH_CACHE.get(sector, {})

--- a/templates/index.html
+++ b/templates/index.html
@@ -124,7 +124,7 @@
                 <tbody>
                     {% for row in rows %}
                     {% set i = loop.index0 %}
-                    <tr data-row-id="{{ i }}" data-status="">
+                    <tr data-row-id="{{ i }}" class="{{ row['row_class'] }}" data-status="">
                         <td><input type="text" class="symbol-input" name="symbol_{{ i }}" value="{{ row['Symbol'] }}" autocomplete="off"></td>
                         <td>
                             <select name="sector_{{ i }}" class="sector-select">
@@ -154,7 +154,7 @@
 
         <br>
         <button name="action" value="parse">Data Search</button>
-        <button type="button" onclick="handleSave()">Зберегти</button>
+        <button name="action" value="calculate">Calculate</button>
         {% if sector_growth_loaded %}
           <div class="status success">✅ Sector Growth loaded</div>
         {% else %}


### PR DESCRIPTION
## Summary
- add calculate button in UI
- support 1d/3d/7d sector growth in normalization
- expose `get_sector_growth_data`
- implement `calculate` action on the backend

## Testing
- `python -m py_compile app.py logic/normalization.py sector_growth_cache.py`

------
https://chatgpt.com/codex/tasks/task_e_6850a29e7e6083229c2d1b52b2e0b1c9