### PR TITLE
Fix sector autofill from cache

### DIFF
--- a/app.py
+++ b/app.py
@@ -148,8 +148,15 @@ def index():
                 rows[i][key] = request.form.get(form_key, '')
 
             if action == "parse" and symbol:
+                if not rows[i].get("Sector"):
+                    cached_sector = get_sector_from_cache(symbol)
+                    if cached_sector:
+                        rows[i]["Sector"] = cached_sector
+
                 parsed = parse_data(symbol)
                 for key, value in parsed.items():
+                    if key == "Sector" and rows[i].get("Sector"):
+                        continue
                     rows[i][key] = value
 
                 sector = rows[i].get("Sector")


### PR DESCRIPTION
## Summary
- pre-fill the sector field from cache when parsing data
- avoid overwriting user-set sector values

## Testing
- `python -m py_compile app.py sector_manager.py logic/* data_fetcher/yfinance_data.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6850cc874f148322914d966d830d91a3