### PR TITLE
Fix custom sector persistence

### DIFF
--- a/sector_manager.py
+++ b/sector_manager.py
@@ -45,7 +45,12 @@ def get_sector_from_cache(symbol: str) -> Optional[str]:
 
 
 def add_sector(symbol: str, sector: str) -> None:
-    """Add or update a symbol to sector mapping and persist it."""
+    """Add a new symbol-to-sector mapping and persist it.
+
+    Existing mappings are left untouched so we don't accidentally
+    overwrite a user-provided sector.
+    """
     data = load_custom_sectors()
-    data[symbol] = sector
-    save_custom_sectors(data)
+    if symbol not in data:
+        data[symbol] = sector
+        save_custom_sectors(data)


### PR DESCRIPTION
## Summary
- ensure `add_sector` persists new mappings to disk without overwriting existing entries

## Testing
- `python -m py_compile sector_manager.py`
- `python -m py_compile app.py data_fetcher/*.py logic/*.py sector_growth_cache.py sector_etf_map.py`


------
https://chatgpt.com/codex/tasks/task_e_6851652a4b88832291d12f40a6490d2c