### PR TITLE
Add TipRanks data fetcher

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 from flask import Flask, render_template, request, jsonify
 from datetime import datetime
-from data_fetcher.zacks import get_zacks_rank
+from data_fetcher import get_zacks_rank, fetch_tipranks_data
 from sector_manager import get_sector_from_cache, add_sector
 from data_fetcher.yfinance_data import get_sector_yf
 from logic.normalization import normalize_row
@@ -20,6 +20,7 @@ app = Flask(__name__)
 HEADERS = [
     "Sector",
     "Zacks",
+    "TipRanks",
     "Sector Growth",
     "EPS Growth",
     "Revenue Growth",
@@ -163,6 +164,10 @@ def index():
                     if key == "Sector" and rows[i].get("Sector"):
                         continue
                     rows[i][key] = value
+
+                tip_data = fetch_tipranks_data(symbol)
+                if tip_data and tip_data.get("tipranks_score") is not None:
+                    rows[i]["TipRanks"] = tip_data["tipranks_score"]
 
                 sector = rows[i].get("Sector")
                 if sector:

--- a/data_fetcher/__init__.py
+++ b/data_fetcher/__init__.py
@@ -1,1 +1,2 @@
 from .zacks import get_zacks_rank
+from .tipranks import fetch_tipranks_data

--- a/data_fetcher/tipranks.py
+++ b/data_fetcher/tipranks.py
@@ -1,0 +1,51 @@
+import random
+import time
+from typing import Dict, Optional
+
+import requests
+
+
+USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:123.0) Gecko/20100101 Firefox/123.0"
+
+
+def fetch_tipranks_data(symbol: str) -> Optional[Dict]:
+    """Fetch TipRanks Smart Score for the given symbol.
+
+    Returns a dictionary containing ``tipranks_score`` and ``is_etf`` or
+    ``None`` if the request fails.
+    """
+    if not symbol:
+        return None
+
+    symbol = symbol.strip().lower()
+    headers = {
+        "User-Agent": USER_AGENT,
+        "Referer": "https://www.tipranks.com/",
+    }
+
+    # Determine if the symbol is an ETF
+    is_etf = -1
+    try:
+        resp = requests.get(f"https://www.tipranks.com/etf/{symbol}", headers=headers, timeout=10)
+        if resp.status_code == 200:
+            is_etf = 1
+    except Exception:
+        pass
+
+    kind = "etf" if is_etf == 1 else "stocks"
+    time.sleep(random.uniform(0.5, 1.1))
+
+    headers["Referer"] = f"https://www.tipranks.com/{kind}/{symbol}"
+    url = f"https://www.tipranks.com/api/{kind}/{symbol}/forecast"
+
+    try:
+        response = requests.get(url, headers=headers, timeout=10)
+        if response.status_code != 200:
+            return None
+        data = response.json()
+        score = data.get("analystConsensus", {}).get("score")
+        if score is None:
+            return None
+        return {"tipranks_score": float(score), "is_etf": is_etf}
+    except Exception:
+        return None

--- a/templates/index.html
+++ b/templates/index.html
@@ -112,6 +112,7 @@
                         <th data-tooltip="Біржовий тикер акції або ETF">Symbol</th>
                         <th data-tooltip="Галузь, до якої належить компанія">Sector</th>
                         <th data-tooltip="Рейтинг Zacks від 1 (сильна покупка) до 5 (продаж)">Zacks</th>
+                        <th>TipRanks</th>
                         <th data-tooltip="Зміна ціни галузевого ETF за певний період">Sector Growth</th>
                         <th data-tooltip="Ріст прибутку на акцію за рік або квартал">EPS Growth</th>
                         <th data-tooltip="Зростання виручки компанії">Revenue Growth</th>
@@ -135,6 +136,7 @@
                             </select>
                         </td>
                         <td><input type="text" class="zacks-output" name="zacks_{{ i }}" value="{{ row['Zacks'] }}"></td>
+                        <td><input type="text" name="tipranks_{{ i }}" value="{{ row['TipRanks'] }}"></td>
                         <td><input type="text" class="sector-growth" name="sector_growth_{{ i }}" value="{{ row['Sector Growth'] }}"></td>
                         <td><input type="text" class="eps-growth" name="eps_growth_{{ i }}" value="{{ row['EPS Growth'] }}"></td>
                         <td><input type="text" class="revenue-growth" name="revenue_growth_{{ i }}" value="{{ row['Revenue Growth'] }}"></td>


### PR DESCRIPTION
## Summary
- implement TipRanks data fetcher with ETF detection
- expose `fetch_tipranks_data` in `data_fetcher`
- wire TipRanks into Flask `data_search` workflow
- extend table with TipRanks column

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851ad6f7a648322aac3ed0e40be5e39