### PR TITLE
Refactor Data Search to fetch rows individually

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,9 @@
 from flask import Flask, render_template, request, jsonify
 from datetime import datetime
 from data_fetcher import get_zacks_rank, fetch_tipranks_data
+from data_fetcher.zacks import fetch_zacks_rank
 from sector_manager import get_sector_from_cache, add_sector
-from data_fetcher.yfinance_data import get_sector_yf
+from data_fetcher.yfinance_data import get_sector_yf, fetch_yfinance_metrics
 from logic.normalization import normalize_row
 from logic.save_handler import save_row
 from sector_growth_cache import (
@@ -122,6 +123,35 @@ def save_data():
         results.append(save_row(normalized))
 
     return jsonify(results)
+
+
+@app.route('/fetch-row', methods=['POST'])
+def fetch_row():
+    payload = request.get_json(force=True)
+    if not isinstance(payload, dict):
+        return jsonify({'error': 'Invalid payload'}), 400
+
+    symbol = (payload.get('symbol') or '').strip()
+    idx = payload.get('idx')
+    if not symbol:
+        return jsonify({'error': 'No symbol provided'}), 400
+
+    zacks = fetch_zacks_rank(symbol)
+    tipranks = fetch_tipranks_data(symbol)
+    yfin = fetch_yfinance_metrics(symbol)
+
+    result = {
+        'idx': idx,
+        'symbol': symbol.upper(),
+        'zacks': zacks,
+        'tipranks': tipranks.get('tipranks_score') if tipranks else None,
+        'eps': yfin.get('eps_growth') if yfin else None,
+        'revenue': yfin.get('revenue_growth') if yfin else None,
+        'pe_ratio': yfin.get('pe_ratio') if yfin else None,
+        'volume': yfin.get('volume_change') if yfin else None,
+    }
+
+    return jsonify(result)
 
 
 @app.route('/', methods=['GET', 'POST'])

--- a/data_fetcher/yfinance_data.py
+++ b/data_fetcher/yfinance_data.py
@@ -36,3 +36,38 @@ def get_sector_yf(symbol: str):
     except Exception:
         pass
     return None
+
+
+def fetch_yfinance_metrics(symbol: str):
+    """Return a dictionary of basic growth metrics via yfinance."""
+    try:
+        ticker = yf.Ticker(symbol)
+        info = ticker.info
+    except Exception:
+        return None
+
+    def pct(val):
+        try:
+            return f"{float(val) * 100:.2f}%"
+        except Exception:
+            return None
+
+    eps_growth = pct(info.get("earningsQuarterlyGrowth"))
+    revenue_growth = pct(info.get("revenueGrowth") or info.get("revenueQuarterlyGrowth"))
+    pe_ratio = info.get("trailingPE")
+
+    volume = info.get("volume")
+    avg_volume = info.get("averageVolume")
+    volume_change = None
+    if volume and avg_volume:
+        try:
+            volume_change = f"{((volume - avg_volume) / avg_volume) * 100:.2f}%"
+        except Exception:
+            volume_change = None
+
+    return {
+        "eps_growth": eps_growth,
+        "revenue_growth": revenue_growth,
+        "pe_ratio": pe_ratio,
+        "volume_change": volume_change,
+    }

--- a/data_fetcher/zacks.py
+++ b/data_fetcher/zacks.py
@@ -39,3 +39,8 @@ def get_zacks_rank(symbol):
 
     # Крок 3: нічого не знайдено
     return "error"
+
+
+def fetch_zacks_rank(symbol: str):
+    """Public wrapper used by API endpoints."""
+    return get_zacks_rank(symbol)

--- a/static/save.js
+++ b/static/save.js
@@ -68,3 +68,48 @@ document.querySelectorAll('.sector-select').forEach(sel => {
         }
     });
 });
+
+async function onDataSearch() {
+    const rows = Array.from(document.querySelectorAll('tbody tr'));
+
+    for (const tr of rows) {
+        if (tr.dataset.processed === 'true') continue;
+
+        const idx = tr.dataset.rowId;
+        const symbol = tr.querySelector('.symbol-input')?.value.trim();
+        if (!symbol) continue;
+
+        const sector = tr.querySelector('.sector-select')?.value.trim();
+
+        try {
+            const resp = await fetch('/fetch-row', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ symbol, sector, idx })
+            });
+            if (!resp.ok) throw new Error('Request failed');
+            const data = await resp.json();
+
+            if (data.zacks !== undefined) tr.querySelector('.zacks-output').value = data.zacks || '';
+            if (data.tipranks !== undefined) tr.querySelector(`input[name="tipranks_${idx}"]`).value = data.tipranks || '';
+            if (data.eps !== undefined) tr.querySelector('.eps-growth').value = data.eps || '';
+            if (data.revenue !== undefined) tr.querySelector('.revenue-growth').value = data.revenue || '';
+            if (data.pe_ratio !== undefined) tr.querySelector('.pe-ratio').value = data.pe_ratio || '';
+            if (data.volume !== undefined) tr.querySelector('.volume-change').value = data.volume || '';
+            tr.querySelector('.date-cell').textContent = new Date().toISOString().slice(0,10);
+
+            tr.classList.remove('row-error');
+            tr.classList.add('row-success');
+            tr.dataset.processed = 'true';
+        } catch (err) {
+            console.log('Fetch row failed', err);
+            tr.classList.remove('row-success');
+            tr.classList.add('row-error');
+            break;
+        }
+
+        await new Promise(r => setTimeout(r, 300));
+    }
+}
+
+document.getElementById('data-search-btn')?.addEventListener('click', onDataSearch);

--- a/templates/index.html
+++ b/templates/index.html
@@ -81,6 +81,7 @@
         }
         .row-ok { background-color: #d4edda; }
         .row-error { background-color: #f8d7da; }
+        .row-success { background-color: #cce5ff; }
         select[data-status="error"], input[data-status="error"] {
             background-color: #f8d7da;
         }
@@ -125,7 +126,7 @@
                 <tbody>
                     {% for row in rows %}
                     {% set i = loop.index0 %}
-                    <tr data-row-id="{{ i }}" class="{{ row['row_class'] }}" data-status="">
+                    <tr data-row-id="{{ i }}" class="{{ row['row_class'] }}" data-status="" data-processed="false">
                         <td><input type="text" class="symbol-input" name="symbol_{{ i }}" value="{{ row['Symbol'] }}" autocomplete="off"></td>
                         <td>
                             <select name="sector_{{ i }}" class="sector-select">
@@ -155,7 +156,7 @@
         </div>
 
         <br>
-        <button name="action" value="data_search">Data Search</button>
+        <button id="data-search-btn" type="button">Data Search</button>
         <button name="action" value="calculate">Calculate</button>
         {% if sector_growth_loaded %}
           <div class="status success">✅ Sector Growth loaded</div>


### PR DESCRIPTION
## Summary
- create `/fetch-row` endpoint for per-row data fetching
- add `fetch_yfinance_metrics` and `fetch_zacks_rank` utilities
- mark table rows with `data-processed` and add blue highlight style
- implement JS `onDataSearch` to fetch each row sequentially
- wire new Data Search button to the async logic

## Testing
- `python -m py_compile app.py sector_growth_cache.py sector_etf_map.py sector_manager.py logic/*.py data_fetcher/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685279580c4c8322beed5a8e39d139f7