### PR TITLE
Skip already parsed rows, return rowIndex

### DIFF
--- a/app.py
+++ b/app.py
@@ -88,6 +88,7 @@ def fetch_data():
         return jsonify({"error": "Invalid JSON"}), 400
 
     symbol = payload.get("symbol") if isinstance(payload, dict) else None
+    row_index = payload.get("rowIndex") if isinstance(payload, dict) else None
     if not symbol or not str(symbol).strip():
         return jsonify({"error": "Symbol is required"}), 400
 
@@ -131,6 +132,8 @@ def fetch_data():
             "volume": "",
             "date": datetime.today().strftime("%Y-%m-%d"),
         }
+        if row_index is not None:
+            result["rowIndex"] = row_index
         return jsonify(result)
     except Exception as e:
         return jsonify({"error": str(e)}), 500

--- a/static/save.js
+++ b/static/save.js
@@ -74,7 +74,8 @@ async function onDataSearch(event) {
     const rows = Array.from(document.querySelectorAll('tbody tr'));
 
     for (const row of rows) {
-        const idx = row.dataset.rowId;
+        if (row.classList.contains('status-success')) continue;
+        const rowIndex = row.dataset.rowId;
         const symbol = row.querySelector('.symbol-input')?.value.trim();
         if (!symbol) continue;
         const sector = row.querySelector('.sector-select')?.value.trim();
@@ -82,7 +83,7 @@ async function onDataSearch(event) {
         await fetch('/fetch-data', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ symbol, sector, idx })
+            body: JSON.stringify({ symbol, sector, rowIndex })
         })
             .then(resp => resp.json())
             .then(data => {
@@ -96,7 +97,7 @@ async function onDataSearch(event) {
                 const zacksEl = row.querySelector('.zacks-output');
                 if (zacksEl) zacksEl.value = zacks ?? '';
 
-                const tipEl = row.querySelector(`input[name="tipranks_${idx}"]`);
+                const tipEl = row.querySelector(`input[name="tipranks_${rowIndex}"]`);
                 if (tipEl) tipEl.value = tipranks ?? '';
 
                 const sectorGrowthEl = row.querySelector('.sector-growth');


### PR DESCRIPTION
## Summary
- skip rows already marked as successful when doing *Data Search*
- send rowIndex with fetch requests
- include rowIndex in `/fetch-data` responses

## Testing
- `python -m py_compile app.py`
- `node --check static/save.js`


------
https://chatgpt.com/codex/tasks/task_e_6852c1bd6f548322a9af332362d1e0d7