### PR TITLE
Ensure TipRanks column and safe parsing

### DIFF
--- a/config/constants.py
+++ b/config/constants.py
@@ -1,12 +1,6 @@
 HEADERS = [
-    "Sector",
-    "Zacks",
-    "TipRanks",
-    "Sector Growth",
-    "EPS Growth",
-    "Revenue Growth",
-    "PE Ratio",
-    "Volume Change",
+    "Sector", "Zacks", "TipRanks", "Sector Growth",
+    "EPS Growth", "Revenue Growth", "PE Ratio", "Volume Change"
 ]
 
 SECTOR_OPTIONS = [

--- a/services/fetch_service.py
+++ b/services/fetch_service.py
@@ -68,6 +68,7 @@ def parse_data(symbol: str) -> Dict:
     return {
         "Sector": sector if sector else "",
         "Zacks": rank,
+        "TipRanks": "",
         "Sector Growth": "",
         "EPS Growth": "",
         "Revenue Growth": "",


### PR DESCRIPTION
## Summary
- include TipRanks header in constants
- initialize empty TipRanks value when parsing data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68531aca7b088322aa01508b453ac312