### PR TITLE
Remove deprecated metrics fields

### DIFF
--- a/config/constants.py
+++ b/config/constants.py
@@ -1,6 +1,12 @@
+# Column headers shown in the UI. The metrics related to EPS growth,
+# revenue growth, PE ratio and volume change have been removed from the
+# backend. The UI still keeps blank columns for layout purposes but they
+# are no longer represented in this list.
 HEADERS = [
-    "Sector", "Zacks", "TipRanks", "Sector Growth",
-    "EPS Growth", "Revenue Growth", "PE Ratio", "Volume Change"
+    "Sector",
+    "Zacks",
+    "TipRanks",
+    "Sector Growth",
 ]
 
 SECTOR_OPTIONS = [

--- a/logic/normalization.py
+++ b/logic/normalization.py
@@ -88,14 +88,6 @@ def normalize_row(row: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         except ValueError:
             pass
 
-    # --- PE Ratio ---
-    pe_raw = _get_value(row, 'pe_ratio', 'PE Ratio')
-    pe_norm: Optional[float] = None
-    pe_val = _parse_float(pe_raw)
-    if pe_val is not None:
-        # Values below 25 are considered good, above 50 very bad
-        pe_norm = round(_clamp(1 - (pe_val / 25)), 4)
-
     # --- Percent-based metrics ---
     def percent_norm(key1: str, key2: str) -> Optional[float]:
         raw = _get_value(row, key1, key2)
@@ -114,19 +106,13 @@ def normalize_row(row: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         _get_value(row, 'sector_growth_7d'), SCALE_7D
     )
 
-    eps_growth_norm = percent_norm('eps_growth', 'EPS Growth')
-    revenue_growth_norm = percent_norm('revenue_growth', 'Revenue Growth')
-    volume_change_norm = percent_norm('volume_change', 'Volume Change')
+
 
     metrics = {
         'zacks_rank_norm': zacks_norm,
-        'pe_ratio_norm': pe_norm,
         'sector_growth_1d_norm': sector_growth_1d_norm,
         'sector_growth_3d_norm': sector_growth_3d_norm,
         'sector_growth_7d_norm': sector_growth_7d_norm,
-        'eps_growth_norm': eps_growth_norm,
-        'revenue_growth_norm': revenue_growth_norm,
-        'volume_change_norm': volume_change_norm,
     }
 
     # If all normalized values are None → treat row as invalid

--- a/services/fetch_service.py
+++ b/services/fetch_service.py
@@ -32,18 +32,6 @@ def build_stock_response(symbol: str, sector: str = "", row_index: Optional[int]
     if tipranks is not None:
         print(f"🎯 TipRanks score parsed: {tipranks}")
 
-    eps_val = fetched.get("eps")
-    eps = eps_val if isinstance(eps_val, (int, float)) else None
-
-    revenue_val = fetched.get("revenue")
-    revenue = revenue_val if isinstance(revenue_val, (int, float)) else None
-
-    pe_val = fetched.get("pe_ratio")
-    pe_ratio = pe_val if isinstance(pe_val, (int, float)) else None
-
-    vol_val = fetched.get("volume")
-    volume = vol_val if isinstance(vol_val, (int, float)) else None
-
     sector_growth = ""
     if sector:
         try:
@@ -57,10 +45,6 @@ def build_stock_response(symbol: str, sector: str = "", row_index: Optional[int]
         "tipranks": tipranks,
         "sector": sector,
         "sector_growth": sector_growth,
-        "eps": eps,
-        "revenue": revenue,
-        "pe_ratio": pe_ratio,
-        "volume": volume,
         "date": datetime.today().strftime("%Y-%m-%d"),
     }
 
@@ -98,8 +82,4 @@ def parse_data(symbol: str) -> Dict:
         "Zacks": rank,
         "TipRanks": tip_val,
         "Sector Growth": "",
-        "EPS Growth": "",
-        "Revenue Growth": "",
-        "PE Ratio": "",
-        "Volume Change": "",
     }

--- a/services/form_handler.py
+++ b/services/form_handler.py
@@ -95,10 +95,6 @@ def process_index_form(req: Request, default_count: int = 5):
                     "sector_growth_1d": sg1,
                     "sector_growth_3d": sg3,
                     "sector_growth_7d": sg7,
-                    "EPS Growth": rows[i].get("EPS Growth"),
-                    "Revenue Growth": rows[i].get("Revenue Growth"),
-                    "PE Ratio": rows[i].get("PE Ratio"),
-                    "Volume Change": rows[i].get("Volume Change"),
                     "Дата": datetime.today().strftime("%Y-%m-%d"),
                 }
 

--- a/static/js/domUtils.js
+++ b/static/js/domUtils.js
@@ -26,17 +26,6 @@ export function fillRowWithData(row, data) {
   const dateEl = row.querySelector('.date-cell');
   if (dateEl) dateEl.textContent = date ?? '';
 
-  const epsEl = row.querySelector('.eps-growth');
-  if (epsEl) epsEl.value = data.eps ?? '';
-
-  const revEl = row.querySelector('.revenue-growth');
-  if (revEl) revEl.value = data.revenue ?? '';
-
-  const peEl = row.querySelector('.pe-ratio');
-  if (peEl) peEl.value = data.pe_ratio ?? '';
-
-  const volEl = row.querySelector('.volume-change');
-  if (volEl) volEl.value = data.volume ?? '';
 }
 
 export function setRowStatus(row, isSuccess) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -119,10 +119,10 @@
                         <th style="width: 55px;" data-tooltip="Рейтинг Zacks від 1 (сильна покупка) до 5 (продаж)">Zacks</th>
                         <th class="tipranks-col" style="width: 90px;">TipRanks</th>
                         <th class="sector-growth" data-tooltip="Зміна ціни галузевого ETF за певний період">Sector Growth</th>
-                        <th class="eps-growth" data-tooltip="Ріст прибутку на акцію за рік або квартал">EPS Growth</th>
-                        <th class="revenue-growth" data-tooltip="Зростання виручки компанії">Revenue Growth</th>
-                        <th class="pe-ratio" data-tooltip="Співвідношення ціни до прибутку">PE Ratio</th>
-                        <th class="volume-change" data-tooltip="Зміна обсягу торгів за добу">Volume Change</th>
+                        <th class="eps-growth">1</th>
+                        <th class="revenue-growth">2</th>
+                        <th class="pe-ratio">3</th>
+                        <th class="volume-change">4</th>
                         <th style="width: 60px;" data-tooltip="Підсумкова оцінка моделі">SkyIndex</th>
                         <th style="width: 90px;" data-tooltip="Дата, на яку зібрані ці дані">Дата</th>
                     </tr>
@@ -143,10 +143,10 @@
                         <td><input type="text" class="zacks-output" name="zacks_{{ i }}" value="{{ row['Zacks'] }}"></td>
                         <td class="tipranks-col"><input type="text" name="tipranks_{{ i }}" value="{{ row['TipRanks'] }}"></td>
                         <td><input type="text" class="sector-growth" name="sector_growth_{{ i }}" value="{{ row['Sector Growth'] }}"></td>
-                        <td><input type="text" class="eps-growth" name="eps_growth_{{ i }}" value="{{ row['EPS Growth'] }}"></td>
-                        <td><input type="text" class="revenue-growth" name="revenue_growth_{{ i }}" value="{{ row['Revenue Growth'] }}"></td>
-                        <td><input type="text" class="pe-ratio" name="pe_ratio_{{ i }}" value="{{ row['PE Ratio'] }}"></td>
-                        <td><input type="text" class="volume-change" name="volume_change_{{ i }}" value="{{ row['Volume Change'] }}"></td>
+                        <td><input type="text" class="eps-growth"></td>
+                        <td><input type="text" class="revenue-growth"></td>
+                        <td><input type="text" class="pe-ratio"></td>
+                        <td><input type="text" class="volume-change"></td>
                         <td style="width: 60px;">
                             {% if row['skyindex_score'] is not none %}
                                 {{ '%.2f'|format(row['skyindex_score']) }}

--- a/tests/mock.html
+++ b/tests/mock.html
@@ -19,10 +19,10 @@
       <th>Zacks</th>
       <th>TipRanks</th>
       <th>Sector Growth</th>
-      <th>EPS Growth</th>
-      <th>Revenue Growth</th>
-      <th>PE Ratio</th>
-      <th>Volume Change</th>
+      <th>1</th>
+      <th>2</th>
+      <th>3</th>
+      <th>4</th>
       <th>Date</th>
     </tr>
   </thead>


### PR DESCRIPTION
## Summary
- trim HEADERS list to only used columns
- drop backend logic for EPS Growth, Revenue Growth, PE Ratio, and Volume Change
- rename related headers in index.html and leave blank inputs
- clean up UI script and sample mock page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685462e43ebc83228d5a31c1c2c2b223