### PR TITLE
Implement metrics caching for stock data

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,14 @@
 from flask import Flask
 
+from services.metrics_cache import reset_cache_if_stale
+
 from routes.index_routes import index_bp
 from routes.fetch_routes import fetch_bp
 
 app = Flask(__name__)
+
+# Clear outdated metrics cache on startup
+reset_cache_if_stale()
 
 app.register_blueprint(index_bp)
 app.register_blueprint(fetch_bp)

--- a/services/metrics_cache.py
+++ b/services/metrics_cache.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from typing import Dict
+
+# Global in-memory cache for fetched metrics
+metrics_cache: Dict[str, Dict] = {}
+
+
+def reset_cache_if_stale() -> None:
+    """Clear cache if the stored date is not today's date."""
+    today = datetime.today().strftime("%Y-%m-%d")
+    if any(entry.get("date") != today for entry in metrics_cache.values()):
+        metrics_cache.clear()

--- a/tests/test_fetch_service.py
+++ b/tests/test_fetch_service.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import datetime
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from services.fetch_service import build_stock_response
+from services.metrics_cache import metrics_cache
+
+
+def test_build_stock_response_caches_metrics():
+    metrics_cache.clear()
+    today = datetime.date.today().strftime('%Y-%m-%d')
+
+    with patch('services.fetch_service.fetcher_manager') as fm, \
+         patch('services.fetch_service.get_sector_from_cache', return_value='Technology'), \
+         patch('services.fetch_service.get_sector_yf', return_value='Technology'), \
+         patch('services.fetch_service.get_sector_growth', return_value='1%'):
+        fm.fetch_all.return_value = {'zacks': '2', 'tipranks': 9}
+        result = build_stock_response('aapl', row_index=1)
+
+    assert result['zacks'] == 2
+    assert result['tipranks'] == 9
+    assert result['sector'] == 'Technology'
+    assert result['sector_growth'] == '1%'
+    assert result['row_class'] == 'row-ok'
+    assert result['rowIndex'] == 1
+    assert metrics_cache['AAPL']['zacks'] == 2
+    assert metrics_cache['AAPL']['tipranks'] == 9
+    assert metrics_cache['AAPL']['date'] == today

--- a/tests/test_form_handler_calculate.py
+++ b/tests/test_form_handler_calculate.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import datetime
+from flask import Flask, request
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from services.form_handler import process_index_form
+from services.metrics_cache import metrics_cache
+
+
+def test_process_index_form_calculate_uses_cache():
+    app = Flask(__name__)
+    metrics_cache.clear()
+    today = datetime.date.today().strftime('%Y-%m-%d')
+    metrics_cache['AAPL'] = {
+        'symbol': 'AAPL',
+        'zacks': 1,
+        'tipranks': 8,
+        'sector': 'Technology',
+        'date': today
+    }
+
+    data = {
+        'rows_count': '1',
+        'action': 'calculate',
+        'symbol_0': 'AAPL',
+        'sector_0': 'Technology',
+        'zacks_0': '',
+        'tipranks_0': '',
+        'sector_growth_0': '1%'
+    }
+
+    with app.test_request_context('/', method='POST', data=data):
+        with patch('services.form_handler.add_sector') as add_sector, \
+             patch('services.form_handler.get_sector_growth', return_value='1%'), \
+             patch('services.form_handler.get_sector_growth_data', return_value={'3d': '2', '7d': '3'}), \
+             patch('services.form_handler.normalize_row') as normalize_row, \
+             patch('services.form_handler.save_row', return_value={'status': 'ok'}):
+            normalize_row.return_value = {
+                'symbol': 'AAPL',
+                'date': today,
+                'metrics': {},
+                'skyindex_score': 0.5
+            }
+            rows = process_index_form(request)
+
+    assert rows[0]['skyindex_score'] == 0.5
+    assert rows[0]['row_class'] == 'row-ok'
+    normalize_row.assert_called()
+    add_sector.assert_called_once_with('AAPL', 'Technology')
+


### PR DESCRIPTION
## Summary
- introduce `metrics_cache` module for global metrics storage
- clear outdated cache on app startup
- cache metrics in `build_stock_response`
- adapt `parse_data` and form handler to use cache
- update calculate flow to rely on cached metrics
- add unit tests for new caching logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685480213d748322bc150acd453bbf82