### PR TITLE
Add TipRanks normalization and integrate into scoring

### DIFF
--- a/logic/rating.py
+++ b/logic/rating.py
@@ -2,9 +2,21 @@ from typing import Any, Dict, Optional
 
 
 def calculate_skyindex_score(metrics: Dict[str, Any]) -> Optional[float]:
-    """Returns the normalized Zacks Rank as the skyindex_score."""
-    value = metrics.get("zacks_rank_norm")
-    try:
-        return float(value)
-    except (TypeError, ValueError):
+    """Calculate a weighted score based on available normalized metrics."""
+    weights_sum = 0.0
+    score = 0.0
+
+    zacks_val = metrics.get("zacks_rank_norm")
+    if isinstance(zacks_val, (int, float)):
+        score += 0.5 * float(zacks_val)
+        weights_sum += 0.5
+
+    tip_val = metrics.get("tipranks_score_norm")
+    if isinstance(tip_val, (int, float)):
+        score += 0.5 * float(tip_val)
+        weights_sum += 0.5
+
+    if weights_sum == 0:
         return None
+
+    return round(score / weights_sum, 4)

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,0 +1,43 @@
+import os
+import sys
+from math import tanh
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from logic.normalization import normalize_row
+
+
+def test_normalize_row_includes_tipranks():
+    row = {
+        "Symbol": "AAPL",
+        "Sector": "Technology",
+        "Zacks": "2",
+        "TipRanks": "8",
+        "sector_growth_1d": "",
+        "sector_growth_3d": "",
+        "sector_growth_7d": "",
+        "Дата": "2025-06-18",
+    }
+    normalized = normalize_row(row)
+    assert normalized is not None
+    metrics = normalized["metrics"]
+    assert metrics["tipranks_score_norm"] == round(tanh((8 - 5) / 2.0), 4)
+    expected_zacks = 0.5
+    expected_tip = round(tanh((8 - 5) / 2.0), 4)
+    expected_score = round(0.5 * expected_zacks + 0.5 * expected_tip, 4)
+    assert normalized["skyindex_score"] == expected_score
+
+
+def test_normalize_row_handles_missing_tipranks():
+    row = {
+        "Symbol": "AAPL",
+        "Sector": "Technology",
+        "Zacks": "2",
+        "sector_growth_1d": "",
+        "sector_growth_3d": "",
+        "sector_growth_7d": "",
+        "Дата": "2025-06-18",
+    }
+    normalized = normalize_row(row)
+    assert normalized is not None
+    assert normalized["metrics"].get("tipranks_score_norm") is None


### PR DESCRIPTION
## Summary
- normalize TipRanks SmartScore in `normalize_row`
- include TipRanks metric in database metrics dict
- weight TipRanks and Zacks rank in `calculate_skyindex_score`
- test TipRanks normalization and scoring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68548fe57c248322a7580a144f9a395e