### PR TITLE
Apply dark theme to index page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5,33 +5,49 @@
     <title>SKY INDEX</title>
     <style>
         body {
-            font-family: Arial, sans-serif;
-            background-color: #f0f2f5;
+            font-family: "Inter", Arial, sans-serif;
+            background-color: #1e1e1e;
+            color: #f3f3f3;
             padding: 20px;
         }
         table {
             border-collapse: collapse;
             margin-top: 20px;
             table-layout: fixed;
+            background-color: #2b2b2b;
+            width: 100%;
         }
         .table-wrapper {
             overflow-x: auto;
             max-width: 100%;
         }
         th, td {
-            border: 1px solid #ddd;
-            padding: 2px;
+            border: 1px solid #444;
+            padding: 4px;
             text-align: left;
         }
         th {
-            background-color: #4CAF50;
-            color: white;
+            background-color: #333;
+            color: #f3f3f3;
+        }
+        tbody tr:nth-child(odd) {
+            background-color: #262626;
         }
         input, select {
             width: 100%;
             padding: 4px;
             font-size: 14px;
             box-sizing: border-box;
+            background-color: #2b2b2b;
+            color: #f3f3f3;
+            border: 1px solid #444;
+            border-radius: 8px;
+            transition: background-color 0.3s, box-shadow 0.3s, border-color 0.3s;
+        }
+        input:focus, select:focus {
+            outline: none;
+            box-shadow: 0 0 4px #10a37f;
+            border-color: #10a37f;
         }
         .symbol-input {
             width: 80px;
@@ -78,16 +94,25 @@
             z-index: 2;
         }
         button {
-            padding: 6px;
+            padding: 6px 12px;
             font-size: 14px;
             margin: 2px;
+            background-color: #10a37f;
+            color: #fff;
+            border: none;
+            border-radius: 8px;
+            cursor: pointer;
+            transition: filter 0.3s;
         }
-        .row-ok { background-color: #d4edda; }
-        .row-error { background-color: #f8d7da; }
-        .status-success { background-color: #d0f0ff; }
-        .status-error { background-color: #ffd6d6; }
+        button:hover {
+            filter: brightness(1.1);
+        }
+        .row-ok { background-color: #224932; }
+        .row-error { background-color: #592e32; }
+        .status-success { background-color: #233c40; }
+        .status-error { background-color: #4b2a2e; }
         select[data-status="error"], input[data-status="error"] {
-            background-color: #f8d7da;
+            background-color: #592e32;
         }
         .row-control {
             display: flex;
@@ -97,8 +122,8 @@
         .row-control input[type="number"] {
             width: 60px;
         }
-        .status.success { color: green; font-weight: bold; }
-        .status.error { color: red; font-weight: bold; }
+        .status.success { color: #10a37f; font-weight: bold; }
+        .status.error { color: #ff6b6b; font-weight: bold; }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- redesign UI with a dark theme similar to ChatGPT
- style inputs, table and buttons for modern dark mode
- add subtle focus glow and hover transitions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: requests, flask)*

------
https://chatgpt.com/codex/tasks/task_e_6854967c9aa883229accf3a1f59ba662