### PR TITLE
Improve dark UI for index dashboard

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -4,12 +4,26 @@
     <meta charset="UTF-8">
     <title>SKY INDEX</title>
     <style>
+        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap');
+
         body {
             font-family: 'Inter', Arial, sans-serif;
             background-color: #1e1e1e;
             color: #f3f3f3;
             padding: 20px;
         }
+
+        h1 {
+            color: #ffffff;
+            font-size: 32px;
+            margin-bottom: 20px;
+        }
+
+        .table-wrapper {
+            overflow-x: auto;
+            max-width: 100%;
+        }
+
         table {
             border-collapse: collapse;
             margin-top: 20px;
@@ -17,26 +31,29 @@
             width: 100%;
             background-color: #2b2b2b;
         }
-        .table-wrapper {
-            overflow-x: auto;
-            max-width: 100%;
-        }
+
         th, td {
             border: 1px solid #444;
-            padding: 2px;
-            text-align: left;
+            padding: 4px;
+            text-align: center;
             background-color: #2b2b2b;
         }
+
         th {
             background-color: #333;
             color: #f3f3f3;
         }
+
+        tbody tr:nth-child(odd) td {
+            background-color: #262626;
+        }
+
         input, select {
             width: 100%;
             padding: 4px;
             font-size: 14px;
             box-sizing: border-box;
-            background-color: #1e1e1e;
+            background-color: #2b2b2b;
             border: 1px solid #444;
             color: #f3f3f3;
             border-radius: 8px;
@@ -83,6 +100,7 @@
         th[data-tooltip] {
             position: relative;
         }
+
         th[data-tooltip]:hover::after {
             content: attr(data-tooltip);
             position: absolute;
@@ -90,33 +108,50 @@
             left: 0;
             background: #333;
             color: #fff;
-            padding: 2px 4px;
+            padding: 4px 6px;
             white-space: nowrap;
-            border-radius: 3px;
+            border-radius: 4px;
             font-size: 12px;
             z-index: 2;
         }
         button {
-            padding: 6px;
+            padding: 6px 12px;
             font-size: 14px;
             margin: 2px;
-            background-color: #2b2b2b;
-            border: 1px solid #444;
-            color: #f3f3f3;
-            border-radius: 8px;
-            transition: background-color 0.2s, filter 0.2s;
-        }
-
-        button[name="action"][value="calculate"] {
             background-color: #10a37f;
-            border-color: #10a37f;
+            color: #ffffff;
+            border: none;
+            border-radius: 8px;
+            cursor: pointer;
+            transition: filter 0.2s;
         }
 
         button:hover {
             filter: brightness(1.1);
         }
-        .row-ok { background-color: #24472f; }
-        .row-error { background-color: #512d2d; }
+
+        button:focus {
+            outline: none;
+        }
+
+        .row-ok {
+            background-color: #224932;
+            color: #c8facc;
+            font-weight: 500;
+            text-align: center;
+            padding: 4px 0;
+            box-shadow: inset 0 0 5px #10a37f44;
+        }
+
+        .row-error {
+            background-color: #5a2a2a;
+            color: #ffc0c0;
+            font-weight: 500;
+            text-align: center;
+            padding: 4px 0;
+            box-shadow: inset 0 0 5px #ff666644;
+        }
+
         .status-success { background-color: #144f3c; }
         .status-error { background-color: #5a2a2a; }
         select[data-status="error"], input[data-status="error"] {
@@ -126,12 +161,22 @@
             display: flex;
             align-items: center;
             gap: 10px;
+            margin-bottom: 10px;
         }
+
         .row-control input[type="number"] {
             width: 60px;
         }
-        .status.success { color: green; font-weight: bold; }
-        .status.error { color: red; font-weight: bold; }
+
+        .status.success {
+            color: #10a37f;
+            font-weight: bold;
+        }
+
+        .status.error {
+            color: #e05d5d;
+            font-weight: bold;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- style with consistent dark theme and Inter font
- unify buttons with GPT green color
- center table text and refine tooltip look
- highlight success/error rows with green/red accents
- minor tweaks to form controls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68549dce15548322b61d7d0c441092e2