### PR TITLE
Improve row status visuals

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -39,6 +39,10 @@
             background-color: #2b2b2b;
         }
 
+        td, th, input, select {
+            text-align: center;
+        }
+
         th {
             background-color: #333;
             color: #f3f3f3;
@@ -135,21 +139,48 @@
         }
 
         .row-ok {
-            background-color: #224932;
-            color: #c8facc;
-            font-weight: 500;
-            text-align: center;
-            padding: 4px 0;
-            box-shadow: inset 0 0 5px #10a37f44;
+            background-color: #1b4d37;
+            color: #12d67d;
+            font-weight: 600;
+            box-shadow: inset 0 0 10px #12d67d99;
         }
 
         .row-error {
-            background-color: #5a2a2a;
-            color: #ffc0c0;
-            font-weight: 500;
-            text-align: center;
-            padding: 4px 0;
-            box-shadow: inset 0 0 5px #ff666644;
+            background-color: #5b2a2a;
+            color: #ff8484;
+            font-weight: 600;
+            box-shadow: inset 0 0 10px #ff848499;
+        }
+
+        tr.row-ok input,
+        tr.row-ok select {
+            background-color: #1b4d37;
+            border-color: #12d67d;
+            color: #eefaf5;
+        }
+
+        tr.row-error input,
+        tr.row-error select {
+            background-color: #5b2a2a;
+            border-color: #ff8484;
+            color: #ffecec;
+        }
+
+        tr.row-ok input:focus,
+        tr.row-ok select:focus {
+            box-shadow: 0 0 6px #12d67d;
+            border-color: #12d67d;
+        }
+
+        tr.row-error input:focus,
+        tr.row-error select:focus {
+            box-shadow: 0 0 6px #ff8484;
+            border-color: #ff8484;
+        }
+
+        .status-label {
+            width: 80px;
+            font-weight: 600;
         }
 
         .status-success { background-color: #144f3c; }
@@ -203,6 +234,7 @@
                         <th class="volume-change">4</th>
                         <th style="width: 60px;" data-tooltip="Підсумкова оцінка моделі">SkyIndex</th>
                         <th style="width: 90px;" data-tooltip="Дата, на яку зібрані ці дані">Дата</th>
+                        <th class="status-label">Status</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -231,6 +263,13 @@
                             {% endif %}
                         </td>
                         <td class="date-cell" style="width: 90px;">{{ row['Дата'] }}</td>
+                        <td class="status-label">
+                            {% if row['row_class'] == 'row-ok' %}
+                                ✅ OK
+                            {% elif row['row_class'] == 'row-error' %}
+                                ❌ Error
+                            {% endif %}
+                        </td>
                     </tr>
                     {% endfor %}
                 </tbody>


### PR DESCRIPTION
## Summary
- center text in all table cells and form controls
- make success and error rows brighter with glowing shadows
- highlight inputs/selects within status rows
- show an extra `Status` column with a label

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a33cb8248322b5a11c095b95afdf