### PR TITLE
Add console log panel to UI

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -11,6 +11,7 @@
             background-color: #1e1e1e;
             color: #f3f3f3;
             padding: 20px;
+            padding-bottom: 150px; /* space for console panel */
         }
 
         h1 {
@@ -208,6 +209,28 @@
             color: #e05d5d;
             font-weight: bold;
         }
+
+        #console-log {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            height: 120px;
+            padding: 8px;
+            background-color: #2b2b2b;
+            color: #ccc;
+            font-family: monospace;
+            font-size: 12px;
+            overflow-y: hidden;
+            border-top-left-radius: 8px;
+            border-top-right-radius: 8px;
+            box-sizing: border-box;
+            z-index: 100;
+        }
+
+        #console-log:hover {
+            overflow-y: auto;
+        }
     </style>
 </head>
 <body>
@@ -285,6 +308,26 @@
           <div class="status error">⚠️ Sector Growth failed</div>
         {% endif %}
     </form>
+    <div id="console-log"></div>
+    <script>
+        (function() {
+            const logDiv = document.getElementById('console-log');
+            const origLog = console.log.bind(console);
+            console.log = function(...args) {
+                const msg = args.map(a => {
+                    if (typeof a === 'object') {
+                        try { return JSON.stringify(a); } catch (e) { return '[object]'; }
+                    }
+                    return String(a);
+                }).join(' ');
+                const line = document.createElement('div');
+                line.textContent = '> ' + msg;
+                logDiv.appendChild(line);
+                logDiv.scrollTop = logDiv.scrollHeight;
+                origLog(...args);
+            };
+        })();
+    </script>
     <script type="module" src="{{ url_for('static', filename='js/main.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- give body extra bottom padding to account for new console log dock
- add styles for fixed #console-log panel
- intercept `console.log()` and output to the dock
- append console panel and log override script in the page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68551f0da76c8322b7a97e9b4f4bb89e