### PR TITLE
Send TipRanks logs to browser console

### DIFF
--- a/fetchers/manager.py
+++ b/fetchers/manager.py
@@ -1,6 +1,6 @@
 """Utility to run multiple fetchers."""
 
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 from .zacks import ZacksFetcher
 from .tipranks import TipranksFetcher
@@ -17,12 +17,15 @@ class FetcherManager:
             YFinanceFetcher(),
         ]
 
-    def fetch_all(self, symbol: str) -> Dict:
+    def fetch_all(self, symbol: str, log_list: Optional[List[str]] = None) -> Dict:
         """Fetch data from all providers and merge the results."""
         result: Dict = {}
         for fetcher in self.fetchers:
             try:
-                data = fetcher.fetch(symbol)
+                if isinstance(fetcher, TipranksFetcher):
+                    data = fetcher.fetch(symbol, log_list)
+                else:
+                    data = fetcher.fetch(symbol)
                 if isinstance(data, dict):
                     result.update(data)
             except Exception as exc:

--- a/routes/fetch_routes.py
+++ b/routes/fetch_routes.py
@@ -20,7 +20,8 @@ def fetch_data():
         return jsonify({"error": "Symbol is required"}), 400
 
     try:
-        result = build_stock_response(symbol, sector=sector, row_index=row_index)
-        return jsonify(result)
+        log_messages: list[str] = []
+        result = build_stock_response(symbol, sector=sector, row_index=row_index, log_messages=log_messages)
+        return jsonify({"success": True, "data": result, "logs": log_messages})
     except Exception as e:
         return jsonify({"error": str(e)}), 500

--- a/services/fetch_service.py
+++ b/services/fetch_service.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional, Dict
+from typing import Optional, Dict, List
 
 from .metrics_cache import metrics_cache
 
@@ -11,7 +11,12 @@ from sector_growth_cache import get_sector_growth
 fetcher_manager = FetcherManager()
 
 
-def build_stock_response(symbol: str, sector: str = "", row_index: Optional[int] = None) -> Dict:
+def build_stock_response(
+    symbol: str,
+    sector: str = "",
+    row_index: Optional[int] = None,
+    log_messages: Optional[List[str]] = None,
+) -> Dict:
     """Fetch metrics for a single stock symbol and assemble JSON response.
 
     Parsed metrics are stored in ``metrics_cache`` for later use by the
@@ -24,7 +29,10 @@ def build_stock_response(symbol: str, sector: str = "", row_index: Optional[int]
     if not sector:
         sector = get_sector_from_cache(symbol) or get_sector_yf(symbol) or ""
 
-    fetched = fetcher_manager.fetch_all(symbol)
+    if log_messages is None:
+        fetched = fetcher_manager.fetch_all(symbol)
+    else:
+        fetched = fetcher_manager.fetch_all(symbol, log_messages)
 
     zacks_raw = fetched.get("zacks")
     zacks = int(zacks_raw) if str(zacks_raw).isdigit() else None

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -16,7 +16,11 @@ async function onDataSearch(event) {
     const sector = row.querySelector('.sector-select')?.value.trim();
 
     try {
-      const data = await fetchRowData({ symbol, sector, rowIndex });
+      const response = await fetchRowData({ symbol, sector, rowIndex });
+      if (response.logs && Array.isArray(response.logs)) {
+        response.logs.forEach(line => console.log(line));
+      }
+      const data = response.data || response;
       fillRowWithData(row, data);
 
       const valid = hasRequiredFields(data);

--- a/templates/index.html
+++ b/templates/index.html
@@ -303,9 +303,9 @@
         <button name="action" value="data_search">Data Search</button>
         <button name="action" value="calculate">Calculate</button>
         {% if sector_growth_loaded %}
-          <div class="status success">✅ Sector Growth loaded</div>
+          <script>console.log('💾 Sector Growth loaded');</script>
         {% else %}
-          <div class="status error">⚠️ Sector Growth failed</div>
+          <script>console.log('⚠️ Sector Growth fetch failed');</script>
         {% endif %}
     </form>
     <div id="console-log"></div>


### PR DESCRIPTION
## Summary
- collect TipRanks warning messages and return them with fetch data
- expose log list via `/fetch-data` API
- display backend logs in frontend console
- update sector growth notice to log in UI console

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685532a711a083229128c3f6d8fcf3d4