### PR TITLE
Improve row status handling in SKY INDEX table

### DIFF
--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -7,4 +7,5 @@ export const REQUIRED_FIELDS = [
 
 export const CLASS_SUCCESS = 'status-success';
 export const CLASS_ERROR = 'status-error';
+export const CLASS_OK_BLUE = 'ok-blue';
 export const FETCH_DELAY_MS = 300;

--- a/static/js/domUtils.js
+++ b/static/js/domUtils.js
@@ -1,4 +1,4 @@
-import { CLASS_SUCCESS, CLASS_ERROR } from './constants.js';
+import { CLASS_SUCCESS, CLASS_ERROR, CLASS_OK_BLUE } from './constants.js';
 
 export function fillRowWithData(row, data) {
   const { symbol, sector, zacks, tipranks, sector_growth, date } = data;
@@ -28,12 +28,23 @@ export function fillRowWithData(row, data) {
 
 }
 
-export function setRowStatus(row, isSuccess) {
-  if (isSuccess) {
-    row.classList.add(CLASS_SUCCESS);
-    row.classList.remove(CLASS_ERROR);
+export function isRowEmpty(row) {
+  const fields = Array.from(row.querySelectorAll('input, select'));
+  return fields.every(el => !el.value);
+}
+
+export function setRowStatus(row, statusClass, statusText = '') {
+  const all = [CLASS_SUCCESS, CLASS_ERROR, CLASS_OK_BLUE];
+  row.classList.remove(...all);
+  if (statusClass) {
+    row.classList.add(statusClass);
+    row.dataset.status = statusClass;
   } else {
-    row.classList.add(CLASS_ERROR);
-    row.classList.remove(CLASS_SUCCESS);
+    delete row.dataset.status;
+  }
+
+  if (statusText !== undefined) {
+    const label = row.querySelector('.status-label');
+    if (label) label.textContent = statusText;
   }
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,7 +1,7 @@
-import { FETCH_DELAY_MS, CLASS_SUCCESS } from './constants.js';
+import { FETCH_DELAY_MS, CLASS_SUCCESS, CLASS_ERROR, CLASS_OK_BLUE } from './constants.js';
 import { fetchRowData } from './fetchRow.js';
 import { hasRequiredFields } from './validators.js';
-import { fillRowWithData, setRowStatus } from './domUtils.js';
+import { fillRowWithData, setRowStatus, isRowEmpty } from './domUtils.js';
 
 
 async function onDataSearch(event) {
@@ -9,7 +9,7 @@ async function onDataSearch(event) {
   const rows = Array.from(document.querySelectorAll('tbody tr'));
 
   for (const row of rows) {
-    if (row.classList.contains(CLASS_SUCCESS)) continue;
+    if (isRowEmpty(row)) continue;
 
     const rowIndex = row.dataset.rowId;
     const symbol = row.querySelector('.symbol-input')?.value.trim();
@@ -23,12 +23,10 @@ async function onDataSearch(event) {
       }
       const data = response.data || response;
       fillRowWithData(row, data);
-
-      const valid = hasRequiredFields(data);
-      setRowStatus(row, valid);
+      setRowStatus(row, CLASS_OK_BLUE, '🔍 OK');
     } catch (err) {
       console.error('Fetch row failed', err);
-      setRowStatus(row, false);
+      setRowStatus(row, CLASS_ERROR, '❌ Error');
     }
 
     await new Promise(r => setTimeout(r, FETCH_DELAY_MS));
@@ -36,3 +34,28 @@ async function onDataSearch(event) {
 }
 
 document.querySelector('button[value="data_search"]')?.addEventListener('click', onDataSearch);
+
+function handleCalculate(event) {
+  event.preventDefault();
+  const rows = Array.from(document.querySelectorAll('tbody tr'));
+
+  for (const row of rows) {
+    if (isRowEmpty(row)) continue;
+
+    const data = {
+      sector: row.querySelector('.sector-select')?.value.trim(),
+      zacks: row.querySelector('.zacks-output')?.value.trim(),
+      tipranks: row.querySelector(`input[name="tipranks_${row.dataset.rowId}"]`)?.value.trim(),
+      sector_growth: row.querySelector('.sector-growth')?.value.trim()
+    };
+
+    const ok = hasRequiredFields(data);
+    if (ok) {
+      setRowStatus(row, CLASS_SUCCESS, '✅ OK');
+    } else {
+      setRowStatus(row, CLASS_ERROR, '❌ Error');
+    }
+  }
+}
+
+document.querySelector('button[value="calculate"]')?.addEventListener('click', handleCalculate);

--- a/templates/index.html
+++ b/templates/index.html
@@ -186,6 +186,7 @@
 
         .status-success { background-color: #144f3c; }
         .status-error { background-color: #5a2a2a; }
+        .ok-blue { background-color: #203858; }
         select[data-status="error"], input[data-status="error"] {
             background-color: #512d2d;
         }

--- a/tests/mock.html
+++ b/tests/mock.html
@@ -8,6 +8,7 @@
   table, th, td { border: 1px solid #ccc; border-collapse: collapse; padding: 4px; }
   .status-success { background-color: #d0f0ff; }
   .status-error { background-color: #ffd6d6; }
+  .ok-blue { background-color: #cde3ff; }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- extend constants with new `ok-blue` status class
- enhance DOM utilities to support generic statuses and empty row checks
- show blue status after successful data fetches
- validate rows during calculation and apply success/error styles
- add blue highlight styling in the main HTML and test page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685555fb36088322a3b838111056c42e