### PR TITLE
Fix row status coloring and validation

### DIFF
--- a/fetchers/manager.py
+++ b/fetchers/manager.py
@@ -19,7 +19,7 @@ class FetcherManager:
 
     def fetch_all(self, symbol: str, log_list: Optional[List[str]] = None) -> Dict:
         """Fetch data from all providers and merge the results."""
-        result: Dict = {}
+        result: Dict = {"row_class": "row-ok"}
         for fetcher in self.fetchers:
             try:
                 if isinstance(fetcher, TipranksFetcher):
@@ -27,7 +27,10 @@ class FetcherManager:
                 else:
                     data = fetcher.fetch(symbol)
                 if isinstance(data, dict):
-                    result.update(data)
+                    if data.get("row_class") == "row-error":
+                        result["row_class"] = "row-error"
+                    result.update({k: v for k, v in data.items() if k != "row_class"})
             except Exception as exc:
                 print(f"Error in {fetcher.__class__.__name__}: {exc}")
+                result["row_class"] = "row-error"
         return result

--- a/fetchers/yfinance_data.py
+++ b/fetchers/yfinance_data.py
@@ -28,18 +28,31 @@ class YFinanceFetcher(BaseFetcher):
     """Fetch basic financial metrics using yfinance."""
 
     def fetch(self, symbol: str) -> Dict[str, Optional[float]]:
-        ticker = yf.Ticker(symbol)
-        info = ticker.info
-        eps = info.get("trailingEps") or info.get("epsTrailingTwelveMonths")
-        revenue = info.get("totalRevenue")
-        pe_ratio = info.get("trailingPE") or info.get("trailingPe")
-        volume = info.get("volume")
-        return {
-            "eps": float(eps) if isinstance(eps, (int, float)) else None,
-            "revenue": float(revenue) if isinstance(revenue, (int, float)) else None,
-            "pe_ratio": float(pe_ratio) if isinstance(pe_ratio, (int, float)) else None,
-            "volume": float(volume) if isinstance(volume, (int, float)) else None,
+        result: Dict[str, Optional[float]] = {
+            "row_class": "row-ok",
+            "eps": None,
+            "revenue": None,
+            "pe_ratio": None,
+            "volume": None,
         }
+
+        try:
+            ticker = yf.Ticker(symbol)
+            info = ticker.info
+            eps = info.get("trailingEps") or info.get("epsTrailingEps") or info.get("epsTrailingTwelveMonths")
+            revenue = info.get("totalRevenue")
+            pe_ratio = info.get("trailingPE") or info.get("trailingPe")
+            volume = info.get("volume")
+            result.update({
+                "eps": float(eps) if isinstance(eps, (int, float)) else None,
+                "revenue": float(revenue) if isinstance(revenue, (int, float)) else None,
+                "pe_ratio": float(pe_ratio) if isinstance(pe_ratio, (int, float)) else None,
+                "volume": float(volume) if isinstance(volume, (int, float)) else None,
+            })
+        except Exception:
+            result["row_class"] = "row-error"
+
+        return result
 
 
 def get_sector_yf(symbol: str) -> Optional[str]:

--- a/fetchers/zacks.py
+++ b/fetchers/zacks.py
@@ -15,8 +15,10 @@ class ZacksFetcher(BaseFetcher):
     """Fetch the Zacks rank for a stock symbol."""
 
     def fetch(self, symbol: str) -> Dict[str, str]:
-        """Return the Zacks rank as a dictionary."""
+        """Return the Zacks rank as a dictionary with status class."""
         time.sleep(random.uniform(ZACKS_DELAY - 0.9, ZACKS_DELAY))
+
+        result: Dict[str, str] = {"row_class": "row-ok", "zacks": "error"}
 
         urls = [
             f"https://www.zacks.com/stock/quote/{symbol}?q={symbol}",
@@ -35,17 +37,21 @@ class ZacksFetcher(BaseFetcher):
                 soup = BeautifulSoup(response.text, "html.parser")
 
                 if soup.find("span", class_="rankrect_NA"):
-                    return {"zacks": "0"}
+                    result["zacks"] = "0"
+                    return result
 
                 for i in range(1, 6):
                     span = soup.find("span", class_=f"rank_chip rankrect_{i}")
                     if span and span.text.strip().isdigit():
-                        return {"zacks": span.text.strip()}
+                        result["zacks"] = span.text.strip()
+                        return result
             except Exception as e:
                 print(f"[!] Error parsing {symbol}: {e}")
+                result["row_class"] = "row-error"
                 continue
 
-        return {"zacks": "error"}
+        result["row_class"] = "row-error"
+        return result
 
 
 # Backward compatible function alias

--- a/services/fetch_service.py
+++ b/services/fetch_service.py
@@ -33,6 +33,7 @@ def build_stock_response(
         fetched = fetcher_manager.fetch_all(symbol)
     else:
         fetched = fetcher_manager.fetch_all(symbol, log_messages)
+    row_class = fetched.pop("row_class", "row-ok")
 
     zacks_raw = fetched.get("zacks")
     zacks = int(zacks_raw) if str(zacks_raw).isdigit() else None
@@ -71,7 +72,7 @@ def build_stock_response(
         "sector": sector,
         "sector_growth": sector_growth,
         "date": today,
-        "row_class": "row-ok" if valid else "row-error",
+        "row_class": "row-ok" if valid and row_class == "row-ok" else "row-error",
     }
 
     if row_index is not None:

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -23,7 +23,19 @@ async function onDataSearch(event) {
       }
       const data = response.data || response;
       fillRowWithData(row, data);
-      setRowStatus(row, CLASS_OK_BLUE, '🔍 OK');
+
+      const valid = data.row_class ? data.row_class === 'row-ok' : hasRequiredFields({
+        sector: data.sector,
+        zacks: data.zacks,
+        tipranks: data.tipranks,
+        sector_growth: data.sector_growth
+      });
+
+      if (valid) {
+        setRowStatus(row, CLASS_OK_BLUE, '🔍 OK');
+      } else {
+        setRowStatus(row, CLASS_ERROR, '❌ Error');
+      }
     } catch (err) {
       console.error('Fetch row failed', err);
       setRowStatus(row, CLASS_ERROR, '❌ Error');

--- a/templates/index.html
+++ b/templates/index.html
@@ -187,6 +187,19 @@
         .status-success { background-color: #144f3c; }
         .status-error { background-color: #5a2a2a; }
         .ok-blue { background-color: #203858; }
+
+        tr.status-success td {
+            background-color: #144f3c;
+            color: #ffffff;
+        }
+        tr.status-error td {
+            background-color: #5a2a2a;
+            color: #ffffff;
+        }
+        tr.ok-blue td {
+            background-color: #203858;
+            color: #ffffff;
+        }
         select[data-status="error"], input[data-status="error"] {
             background-color: #512d2d;
         }

--- a/tests/test_fetch_service.py
+++ b/tests/test_fetch_service.py
@@ -17,7 +17,7 @@ def test_build_stock_response_caches_metrics():
          patch('services.fetch_service.get_sector_from_cache', return_value='Technology'), \
          patch('services.fetch_service.get_sector_yf', return_value='Technology'), \
          patch('services.fetch_service.get_sector_growth', return_value='1%'):
-        fm.fetch_all.return_value = {'zacks': '2', 'tipranks': 9}
+        fm.fetch_all.return_value = {'zacks': '2', 'tipranks': 9, 'row_class': 'row-ok'}
         result = build_stock_response('aapl', row_index=1)
 
     assert result['zacks'] == 2


### PR DESCRIPTION
## Summary
- verify fetched rows and color blue only when data valid
- apply error status when fields missing
- color table rows correctly in blue, red, and green
- propagate `row_class` from fetchers so frontend knows if parsing succeeded

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685560391ffc8322a06c3e7e0656d7c1