### PR TITLE
Fix ok-blue row styling

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -168,6 +168,7 @@
 
     .status-success { background-color: #144f3c; }
     .status-error { background-color: #5a2a2a; }
+    .ok-blue { background-color: #203858; }
 
     select[data-status="error"], input[data-status="error"] {
       background-color: #512d2d;


### PR DESCRIPTION
## Summary
- style `.ok-blue` rows consistently

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855731601dc8322bb058e17a64c67c3