### PR TITLE
Conditionally populate logs for Data Search

### DIFF
--- a/routes/index_routes.py
+++ b/routes/index_routes.py
@@ -13,10 +13,11 @@ index_bp = Blueprint('index_bp', __name__)
 def index():
     rows = process_index_form(request)
     logs: list[str] = []
-    if sector_growth_loaded:
-        logs.append("✅ Sector Growth loaded")
-    else:
-        logs.append("⚠️ Sector Growth failed to load")
+    if request.method == "POST" and request.form.get("action") == "data_search":
+        if sector_growth_loaded:
+            logs.append("✅ Sector Growth loaded")
+        else:
+            logs.append("⚠️ Sector Growth failed to load")
     return render_template(
         'index.html',
         headers=HEADERS,


### PR DESCRIPTION
## Summary
- only fill `logs` in `index()` when the Data Search button is used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855cbaeadb083228f95a56f4ca6defd