### PR TITLE
Fix logs not appearing after Data Search

### DIFF
--- a/routes/index_routes.py
+++ b/routes/index_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, request
+from flask import Blueprint, render_template, request, jsonify
 
 from services.form_handler import (
     process_index_form,
@@ -26,3 +26,13 @@ def index():
         sector_growth_loaded=sector_growth_loaded,
         logs=logs,
     )
+
+
+@index_bp.route('/api/logs')
+def get_logs():
+    logs = []
+    if sector_growth_loaded:
+        logs.append("✅ Sector Growth loaded")
+    else:
+        logs.append("⚠️ Sector Growth failed to load")
+    return jsonify(logs=logs)

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -46,7 +46,15 @@ async function onDataSearch(event) {
   }
 }
 
-document.querySelector('button[value="data_search"]')?.addEventListener('click', onDataSearch);
+const dataSearchBtn = document.querySelector('button[value="data_search"]');
+dataSearchBtn?.addEventListener('click', async (event) => {
+  await onDataSearch(event);
+  const res = await fetch('/api/logs');
+  const data = await res.json();
+  if (data.logs) {
+    data.logs.forEach(msg => console.log(msg));
+  }
+});
 
 function handleCalculate(event) {
   event.preventDefault();


### PR DESCRIPTION
## Summary
- add new `/api/logs` endpoint that reports sector growth load state
- fetch this API after clicking Data Search and print messages in console

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d9d6077c832294ce4006823e9da6